### PR TITLE
docs: use label match in SERVICECIDR command for KinD

### DIFF
--- a/docs/content/en/docs/getting-started/network.md
+++ b/docs/content/en/docs/getting-started/network.md
@@ -31,7 +31,7 @@ export SERVICECIDR=$(gcloud container clusters describe ${NAME} --zone ${ZONE} |
 {{< /tab >}}
 
 {{< tab Kind >}}
-export SERVICECIDR=$(kubectl describe pod -n kube-system kube-apiserver-kind-control-plane | awk -F= '/--service-cluster-ip-range/ {print $2; }')
+export SERVICECIDR=$(kubectl describe pod -n kube-system -l component=kube-apiserver | awk -F= '/--service-cluster-ip-range/ {print $2; }')
 {{< /tab >}}
 
 {{< tab EKS >}}


### PR DESCRIPTION
Fixes #3182

<!--
Thanks for contributing! Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit message and are signed-off (see [Submitting a pull request](https://tetragon.io/docs/contribution-guide/submitting-a-pull-request/)).
- [ ] All code is covered by unit and/or end-to-end tests where feasible.
- [ ] All generated files are updated if needed (see [Making changes](https://tetragon.io/docs/contribution-guide/making-changes/)).
- [ ] Provide a title or release-note blurb suitable for the release notes (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#release-note-blurb-in-pr)).
- [x] Update documentation and write an upgrade note if needed (see [guidelines](https://tetragon.io/docs/contribution-guide/docs/release-notes/#upgrade-notes)).
- [ ] Are you a user of Tetragon? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md) in the Cilium repository.
-->

### Description
<!-- Please describe quickly the change but most importantly the reason or context of your change -->
Use `component=kube-apiserver` match in doc command for getting the SERVICECIDR on KinD clusters

Named KinD clusters will have kube-apiserver pods with the cluster name included--the format is `kube-apiserver-<CLUSTERNAME>-control-plane`.  The kube-system control-plane uses the label `component=kube-apiserver` on the apiserver pods regardless of the cluster name.
